### PR TITLE
Add site-header CSS

### DIFF
--- a/github_dark.css
+++ b/github_dark.css
@@ -734,7 +734,7 @@ background-position: left top !important;
     background: #181818 !important;
     border-color: #484848 !important;
   }
-  .header, .headers, #readme .markdown-body, .social-count, .file, .box-body,
+  .header, .site-header, .headers, #readme .markdown-body, .social-count, .file, .box-body,
   .markdown-body table tr:nth-child(2n), .steps li,
   .explore-section:nth-child(2n), .markdown-format table, .list-group-item,
   .chromed-list-browser .none p, .chromed-list-browser .error p,


### PR DESCRIPTION
Previously the header on github blog pages looked white:

![screenshot_for_styles](https://cloud.githubusercontent.com/assets/5606260/14294578/da6f87f2-fb3f-11e5-9939-d63c8e27b954.png)

Now it looks the same as the other headers:

![screenshot_for_styles2](https://cloud.githubusercontent.com/assets/5606260/14294587/e4ed345e-fb3f-11e5-9c4c-71f6afd52352.png)

Not sure if the text in this header should be blue or not though.
